### PR TITLE
rucio-clients v1.29.0 with updated requirements

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "rucio-clients" %}
-{% set version = "1.28.7" %}
+{% set version = "1.29.0" %}
 
 
 package:
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/rucio-clients-{{ version }}.tar.gz
-  sha256: 9a506ce197d9893f211a8569fce63131050aa987293292d2a96c797e20575f32
+  sha256: 08459ef5f7086b4d622c6df19898e0bb13f7ab3384101c0ccb9d5b99f2e284dc
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,11 +20,10 @@ requirements:
     - pip
     - python >=3.6
   run:
-    - dogpile.cache >=0.6.5,<=1.1.5
+    - dogpile.cache >=1.1.2,<=1.1.5
     - jsonschema ~=3.2.0
     - python >=3.6
     - requests >=2.20.0,<=2.27.1
-    - six >=1.12.0,<=1.16.0
     - tabulate ~=0.8.0
     - urllib3 >=1.24.2,<=1.26.8
 


### PR DESCRIPTION
Closes #28 

This PR includes the version bump from the auto-generated bot PR (#28), in addition to updating the feedstock requirements in `meta.yaml`.