### PR TITLE
Align client dependencies with upstream metadata

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: 28c5bdc784e13053448835997927633e5c745bd0b5d64dfe6279fdb98698f5ff
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,15 +22,15 @@ requirements:
     - setuptools
   run:
     - python >={{ python_min }}
-    - click >=8.1.8
-    - dogpile.cache >=1.2.2
-    - jsonschema >=4.25.1
-    - packaging >=25.0
-    - requests >=2.32.5
-    - rich >=14.2.0
-    - tabulate >=0.9.0
-    - typing_extensions >=4.15.0
-    - urllib3 >=2.6.3
+    - click
+    - dogpile.cache
+    - jsonschema
+    - packaging
+    - requests
+    - rich
+    - tabulate
+    - typing_extensions
+    - urllib3
 
 test:
   imports:


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

## Summary

Removes conda-only lower bounds from the runtime dependencies so the recipe matches the [Rucio client metadata](https://github.com/rucio/rucio/blob/41.1.0/pyproject.client.toml#L24-L35).

The build number is incremented to `1` following the merge of [PR #152](https://github.com/conda-forge/rucio-clients-feedstock/pull/152), which introduced version 41.1.0 as build 0.

## Validation

- Local package builds passed the import tests and `pip check`
- The installed Rucio payload is unchanged
- Fresh local solves selected the same dependency versions
- Rerendering is not required because the feedstock configuration and build matrix are unchanged